### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Project overview
+
+This is **setup-cangjie**, a GitHub Action that installs the Cangjie (仓颉) programming language SDK into GitHub Actions runners. It is a single TypeScript project (not a monorepo).
+
+- **Runtime**: Node.js 24 (specified in `action.yml`)
+- **Package manager**: pnpm 10.33.0 (see `packageManager` in `package.json`)
+- **Build**: Rollup bundles `src/index.ts` → `dist/index.js`
+
+### Available commands
+
+| Command | Description |
+|---|---|
+| `pnpm run lint` | Run ESLint |
+| `pnpm run lint:fix` | Run ESLint with auto-fix |
+| `pnpm run build` | Bundle TypeScript via Rollup to `dist/index.js` |
+| `pnpm run dev` | Run source directly via `tsx` (requires GitHub Actions env) |
+
+### Caveats
+
+- `pnpm run dev` will always fail outside a GitHub Actions runner because it depends on `@actions/core` environment variables (`RUNNER_TEMP`, `INPUT_*`, etc.). This is expected.
+- End-to-end testing can only be done through GitHub Actions CI (`.github/workflows/test.yml`). Locally, validate via `pnpm run lint` and `pnpm run build`.
+- Build warnings about `"this" has been rewritten to "undefined"` and circular dependencies are from upstream `@actions/*` packages and are harmless.
+- The `pnpm.onlyBuiltDependencies` field in `package.json` restricts native builds to `esbuild` only; no interactive `pnpm approve-builds` is needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `AGENTS.md` with Cursor Cloud specific instructions for future cloud agents working in this repository.

### What's included

- Project overview (GitHub Action for Cangjie SDK setup)
- Available development commands (`lint`, `build`, `dev`)
- Key caveats:
  - `pnpm run dev` requires GitHub Actions runner environment
  - End-to-end testing only possible through CI
  - Build warnings from upstream `@actions/*` packages are harmless
  - `pnpm.onlyBuiltDependencies` avoids interactive approval prompts

### Environment verification

All development commands verified:

- `pnpm install` — dependencies install successfully
- `pnpm run lint` — ESLint passes with zero errors
- `pnpm run build` — Rollup builds `dist/index.js` successfully
- `pnpm run dev` — TypeScript compiles and runs via `tsx` (fails as expected outside GitHub Actions runner)

[dev_env_setup.log](https://cursor.com/agents/bc-919b71f5-29a5-41b1-92a6-171ad5921400/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdev_env_setup.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-919b71f5-29a5-41b1-92a6-171ad5921400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-919b71f5-29a5-41b1-92a6-171ad5921400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

